### PR TITLE
control serde and JSON features behind a feature flag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: stable
 
-      - run: cargo test
+      - run: cargo test --features "use-serde"
 
       - uses: jetli/wasm-pack-action@v0.3.0
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - run: cargo test
+      - run: cargo test --features "use-serde"
 
       - uses: jetli/wasm-pack-action@v0.3.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ name = "cirru_parser"
 version = "0.1.17"
 dependencies = [
  "criterion",
+ "serde",
  "serde_json",
 ]
 
@@ -415,9 +416,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
 
 [[package]]
 name = "serde_cbor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,17 @@ exclude = [
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+use-serde = ["serde", "serde_json"]
 
+# ['cfg(features = "use-serde")'.dependencies]
 [dependencies]
-serde = "1.0.131"
+serde = { version = "1.0.131", optional = true }
+serde_json = { version = "1.0.71", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.71"
 criterion = "0.3"
-
 
 [lib]
 name = "cirru_parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = "1.0.131"
 
 [dev-dependencies]
 serde_json = "1.0.71"

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use cirru_parser::Cirru;
+use crate::Cirru;
 
 /// parse JSON `["a", ["b"]]` into Cirru,
 /// only Arrays and Strings are accepted

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,6 +28,12 @@ mod s_expr;
 mod tree;
 mod writer;
 
+#[cfg(feature = "use-serde")]
+mod json;
+
+#[cfg(feature = "use-serde")]
+pub use json::*;
+
 use std::cmp;
 
 use primes::CirruLexState;

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -5,8 +5,11 @@ use std::hash::{Hash, Hasher};
 use std::str;
 // use std::marker::Copy;
 
+#[cfg(feature = "use-serde")]
 use serde::de::{SeqAccess, Visitor};
+#[cfg(feature = "use-serde")]
 use serde::ser::SerializeSeq;
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::s_expr;
@@ -176,6 +179,7 @@ impl Cirru {
   }
 }
 
+#[cfg(feature = "use-serde")]
 impl Serialize for Cirru {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
@@ -194,6 +198,7 @@ impl Serialize for Cirru {
   }
 }
 
+#[cfg(feature = "use-serde")]
 impl<'de> Visitor<'de> for Cirru {
   type Value = Cirru;
 
@@ -218,6 +223,7 @@ impl<'de> Visitor<'de> for Cirru {
   }
 }
 
+#[cfg(feature = "use-serde")]
 impl<'de> Deserialize<'de> for Cirru {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where

--- a/tests/indent_test.rs
+++ b/tests/indent_test.rs
@@ -1,3 +1,5 @@
+extern crate cirru_parser;
+
 use cirru_parser::CirruLexItem;
 use cirru_parser::{lex, resolve_indentations};
 

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -5,17 +5,7 @@ use cirru_parser::Cirru;
 /// parse JSON `["a", ["b"]]` into Cirru,
 /// only Arrays and Strings are accepted
 pub fn from_json_value(x: Value) -> Cirru {
-  match x {
-    Value::Array(ys) => {
-      let mut r: Vec<Cirru> = vec![];
-      for y in ys {
-        r.push(from_json_value(y));
-      }
-      Cirru::List(r)
-    }
-    Value::String(s) => Cirru::Leaf(s.into_boxed_str()),
-    _ => unreachable!("only string and array are expected"),
-  }
+  serde_json::from_value(x).unwrap()
 }
 
 /// parse JSON string `r#"["a", ["b"]]"#` into Cirru,
@@ -30,16 +20,7 @@ pub fn from_json_str(s: &str) -> Result<Cirru, String> {
 
 /// generates JSON from Cirru Data
 pub fn to_json_value(x: Cirru) -> Value {
-  match x {
-    Cirru::Leaf(s) => Value::String((*s).to_string()),
-    Cirru::List(ys) => {
-      let mut zs: Vec<Value> = vec![];
-      for y in ys {
-        zs.push(to_json_value(y));
-      }
-      Value::Array(zs)
-    }
-  }
+  serde_json::to_value(x).unwrap()
 }
 
 /// generates JSON string from Cirru Data

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -1,3 +1,5 @@
+extern crate cirru_parser;
+
 use cirru_parser::lex;
 use cirru_parser::CirruLexItem;
 

--- a/tests/order_test.rs
+++ b/tests/order_test.rs
@@ -1,3 +1,5 @@
+extern crate cirru_parser;
+
 use cirru_parser::Cirru;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,64 +1,65 @@
-use std::fs;
-use std::io;
+extern crate cirru_parser;
 
-use serde_json::json;
+#[cfg(feature = "use-serde")]
+mod json_test {
+  use std::fs;
+  use std::io;
 
-mod json;
+  use serde_json::json;
 
-use cirru_parser::{parse, Cirru};
+  use cirru_parser::{from_json_str, from_json_value, parse, Cirru};
 
-use json::{from_json_str, from_json_value};
+  #[test]
+  fn parse_demo() {
+    assert_eq!(parse("a").map(Cirru::List), from_json_str(r#"[["a"]]"#));
 
-#[test]
-fn parse_demo() {
-  assert_eq!(parse("a").map(Cirru::List), from_json_str(r#"[["a"]]"#));
+    assert_eq!(
+      parse("a b c").map(Cirru::List),
+      from_json_str(r#"[["a", "b", "c"]]"#)
+    );
 
-  assert_eq!(
-    parse("a b c").map(Cirru::List),
-    from_json_str(r#"[["a", "b", "c"]]"#)
-  );
+    assert_eq!(
+      parse("a\nb").map(Cirru::List),
+      from_json_str(r#"[["a"], ["b"]]"#)
+    );
 
-  assert_eq!(
-    parse("a\nb").map(Cirru::List),
-    from_json_str(r#"[["a"], ["b"]]"#)
-  );
+    assert_eq!(
+      parse("a (b) c").map(Cirru::List),
+      Ok(from_json_value(json!([["a", ["b"], "c"]])))
+    );
 
-  assert_eq!(
-    parse("a (b) c").map(Cirru::List),
-    Ok(from_json_value(json!([["a", ["b"], "c"]])))
-  );
+    assert_eq!(
+      parse("a (b)\n  c").map(Cirru::List),
+      Ok(from_json_value(json!([["a", ["b"], ["c"]]])))
+    );
 
-  assert_eq!(
-    parse("a (b)\n  c").map(Cirru::List),
-    Ok(from_json_value(json!([["a", ["b"], ["c"]]])))
-  );
-
-  assert_eq!(parse("").map(Cirru::List), from_json_str(r#"[]"#));
-}
-
-#[test]
-fn parse_files() -> Result<(), io::Error> {
-  let files = vec![
-    "comma",
-    "demo",
-    "folding",
-    "html",
-    "indent-twice",
-    "indent",
-    "let",
-    "line",
-    "paren-indent",
-    "paren-indent2", // same result as parent-indent
-    "parentheses",
-    "quote",
-    "spaces",
-    "unfolding",
-  ];
-  for file in files {
-    println!("testing file: {}", file);
-    let json_str = fs::read_to_string(format!("./tests/data/{}.json", file))?;
-    let cirru_str = fs::read_to_string(format!("./tests/cirru/{}.cirru", file))?;
-    assert_eq!(parse(&cirru_str).map(Cirru::List), from_json_str(&json_str));
+    assert_eq!(parse("").map(Cirru::List), from_json_str(r#"[]"#));
   }
-  Ok(())
+
+  #[test]
+  fn parse_files() -> Result<(), io::Error> {
+    let files = vec![
+      "comma",
+      "demo",
+      "folding",
+      "html",
+      "indent-twice",
+      "indent",
+      "let",
+      "line",
+      "paren-indent",
+      "paren-indent2", // same result as parent-indent
+      "parentheses",
+      "quote",
+      "spaces",
+      "unfolding",
+    ];
+    for file in files {
+      println!("testing file: {}", file);
+      let json_str = fs::read_to_string(format!("./tests/data/{}.json", file))?;
+      let cirru_str = fs::read_to_string(format!("./tests/cirru/{}.cirru", file))?;
+      assert_eq!(parse(&cirru_str).map(Cirru::List), from_json_str(&json_str));
+    }
+    Ok(())
+  }
 }

--- a/tests/primes_test.rs
+++ b/tests/primes_test.rs
@@ -1,3 +1,5 @@
+extern crate cirru_parser;
+
 use cirru_parser::Cirru;
 
 #[test]

--- a/tests/s_expr_test.rs
+++ b/tests/s_expr_test.rs
@@ -1,3 +1,5 @@
+extern crate cirru_parser;
+
 use cirru_parser::{parse, Cirru};
 
 #[test]

--- a/tests/writer_test.rs
+++ b/tests/writer_test.rs
@@ -1,110 +1,114 @@
-use std::fs;
-use std::io;
+extern crate cirru_parser;
 
-mod json;
+use cirru_parser::escape_cirru_leaf;
 
-use json::from_json_str;
+#[cfg(feature = "use-serde")]
+mod json_write_test {
+  use super::*;
 
-use cirru_parser::{escape_cirru_leaf, format, Cirru, CirruWriterOptions};
+  use cirru_parser::{format, from_json_str, Cirru, CirruWriterOptions};
+  use std::fs;
+  use std::io;
 
-#[test]
-fn write_demo() -> Result<(), String> {
-  let writer_options = CirruWriterOptions { use_inline: false };
-
-  match from_json_str(r#"[["a"], ["b"]]"#) {
-    Ok(tree) => {
-      if let Cirru::List(xs) = tree {
-        assert_eq!("\na\n\nb\n", format(&xs, writer_options)?)
-      } else {
-        panic!("unexpected leaf here")
-      }
-    }
-    Err(e) => {
-      println!("file err: {}", e);
-      panic!("failed to load edn data from JSON");
-    }
-  };
-
-  if let Cirru::List(xs) = from_json_str(r#"[["中文"], ["中文"]]"#).unwrap() {
-    assert_eq!("\n\"中文\"\n\n\"中文\"\n", format(&xs, writer_options)?)
-  } else {
-    panic!("unexpected leaf here")
-  }
-
-  Ok(())
-}
-
-#[test]
-fn write_files() -> Result<(), io::Error> {
-  let files = vec![
-    "append-indent",
-    "comma-indent",
-    "cond-short",
-    "cond",
-    "demo",
-    "double-nesting",
-    "fold-vectors",
-    "folding",
-    // "html-inline",
-    "html",
-    "indent",
-    "inline-let",
-    // "inline-mode",
-    "inline-simple",
-    "line",
-    "nested-2",
-    "parentheses",
-    "quote",
-    "spaces",
-    "unfolding",
-  ];
-  for file in files {
-    println!("testing file: {}", file);
-    let json_str = fs::read_to_string(format!("./tests/writer_data/{}.json", file))?;
-    let cirru_str = fs::read_to_string(format!("./tests/writer_cirru/{}.cirru", file))?;
-
+  #[test]
+  fn write_demo() -> Result<(), String> {
     let writer_options = CirruWriterOptions { use_inline: false };
-    match from_json_str(&json_str) {
+
+    match from_json_str(r#"[["a"], ["b"]]"#) {
       Ok(tree) => {
         if let Cirru::List(xs) = tree {
-          assert_eq!(cirru_str, format(&xs, writer_options).unwrap());
+          assert_eq!("\na\n\nb\n", format(&xs, writer_options)?)
         } else {
           panic!("unexpected leaf here")
         }
       }
       Err(e) => {
-        println!("{:?}", e);
-        panic!("failed to load edn data from json");
+        println!("file err: {}", e);
+        panic!("failed to load edn data from JSON");
       }
+    };
+
+    if let Cirru::List(xs) = from_json_str(r#"[["中文"], ["中文"]]"#).unwrap() {
+      assert_eq!("\n\"中文\"\n\n\"中文\"\n", format(&xs, writer_options)?)
+    } else {
+      panic!("unexpected leaf here")
     }
+
+    Ok(())
   }
-  Ok(())
-}
 
-#[test]
-fn write_with_inline() -> Result<(), io::Error> {
-  let files = vec!["html-inline", "inline-mode"];
-  for file in files {
-    println!("testing file: {}", file);
-    let json_str = fs::read_to_string(format!("./tests/writer_data/{}.json", file))?;
-    let cirru_str = fs::read_to_string(format!("./tests/writer_cirru/{}.cirru", file))?;
+  #[test]
+  fn write_files() -> Result<(), io::Error> {
+    let files = vec![
+      "append-indent",
+      "comma-indent",
+      "cond-short",
+      "cond",
+      "demo",
+      "double-nesting",
+      "fold-vectors",
+      "folding",
+      // "html-inline",
+      "html",
+      "indent",
+      "inline-let",
+      // "inline-mode",
+      "inline-simple",
+      "line",
+      "nested-2",
+      "parentheses",
+      "quote",
+      "spaces",
+      "unfolding",
+    ];
+    for file in files {
+      println!("testing file: {}", file);
+      let json_str = fs::read_to_string(format!("./tests/writer_data/{}.json", file))?;
+      let cirru_str = fs::read_to_string(format!("./tests/writer_cirru/{}.cirru", file))?;
 
-    let writer_options = CirruWriterOptions { use_inline: true };
-    match from_json_str(&json_str) {
-      Ok(tree) => {
-        if let Cirru::List(xs) = tree {
-          assert_eq!(cirru_str, format(&xs, writer_options).unwrap());
-        } else {
-          panic!("unexpected literal here")
+      let writer_options = CirruWriterOptions { use_inline: false };
+      match from_json_str(&json_str) {
+        Ok(tree) => {
+          if let Cirru::List(xs) = tree {
+            assert_eq!(cirru_str, format(&xs, writer_options).unwrap());
+          } else {
+            panic!("unexpected leaf here")
+          }
+        }
+        Err(e) => {
+          println!("{:?}", e);
+          panic!("failed to load edn data from json");
         }
       }
-      Err(e) => {
-        println!("file err: {:?}", e);
-        panic!("failed to load edn form data");
+    }
+    Ok(())
+  }
+
+  #[test]
+  fn write_with_inline() -> Result<(), io::Error> {
+    let files = vec!["html-inline", "inline-mode"];
+    for file in files {
+      println!("testing file: {}", file);
+      let json_str = fs::read_to_string(format!("./tests/writer_data/{}.json", file))?;
+      let cirru_str = fs::read_to_string(format!("./tests/writer_cirru/{}.cirru", file))?;
+
+      let writer_options = CirruWriterOptions { use_inline: true };
+      match from_json_str(&json_str) {
+        Ok(tree) => {
+          if let Cirru::List(xs) = tree {
+            assert_eq!(cirru_str, format(&xs, writer_options).unwrap());
+          } else {
+            panic!("unexpected literal here")
+          }
+        }
+        Err(e) => {
+          println!("file err: {:?}", e);
+          panic!("failed to load edn form data");
+        }
       }
     }
+    Ok(())
   }
-  Ok(())
 }
 
 #[test]


### PR DESCRIPTION
需要通过参数开启相关功能,

```bash
cargo test --features "use-serde"
```

大致的修改, 先在 `Cargo.toml` 里配置定义 features, 默认先不开启. 如果开启 "use-serde", 同事也开启数组里的两个 crates 的使用:

```toml
[features]
default = []
use-serde = ["serde", "serde_json"]
```

依赖声明为 optional, 默认情况不要编译, 我的期望是在 Cirru EDN 和 Calcit 当中不要把这两个模块编译进去,
本来想把测试用的那个也做成 optional, 但提示不允许,

```toml
[dependencies]
serde = { version = "1.0.131", optional = true }
serde_json = { version = "1.0.71", optional = true }
```

代码当中需要逐个控制, 只有开启了 `use-serde` 才能把所有引用到 serde 的代码都激活,

```rust
#[cfg(feature = "use-serde")]
```

目前实现可能存在遗漏, 后续再其他项目使用过程当中再验证效果.

参考文档 https://doc.rust-lang.org/cargo/reference/features.html 