### PR TITLE
feat: configure focused Cirru previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "cirru_parser"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "cirru_parser"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ let escaped = escape_cirru_leaf("a b");
 assert_eq!(escaped, "\"a b\"");
 ```
 
+### Focused tree previews
+
+`focus_cirru_preview` returns a compact presentation tree around a numeric
+path. Its default output is backward compatible. Tools can customize the
+presentation marker, preserve a semantic root prefix, and tune folding limits
+without changing the source tree:
+
+```rust
+use cirru_parser::{Cirru, CirruFocusOptions, focus_cirru_preview_with_options};
+
+let tree = Cirru::List(vec![
+    Cirru::leaf("defn"),
+    Cirru::leaf("render"),
+    Cirru::List(vec![Cirru::leaf("value")]),
+    Cirru::List(vec![Cirru::leaf("println"), Cirru::leaf("value")]),
+]);
+let options = CirruFocusOptions::default()
+    .with_focus_marker("CURSOR")
+    .with_root_prefix(3)
+    .with_target_limits(3, 2);
+let preview = focus_cirru_preview_with_options(&tree, &[3, 1], &options);
+```
+
 ## Features
 
 This crate provides the following features:

--- a/examples/focus_cirru_preview.rs
+++ b/examples/focus_cirru_preview.rs
@@ -6,7 +6,9 @@
 //! cargo run --example focus_cirru_preview
 //! ```
 
-use cirru_parser::{Cirru, CirruOneLinerParseExt, CirruWriterOptions, focus_cirru_preview, format};
+use cirru_parser::{
+  Cirru, CirruFocusOptions, CirruOneLinerParseExt, CirruWriterOptions, focus_cirru_preview, focus_cirru_preview_with_options, format,
+};
 
 fn path_exists(node: &Cirru, path: &[usize]) -> bool {
   let mut current = node;
@@ -75,6 +77,22 @@ fn main() -> Result<(), String> {
   for (code, paths) in cases {
     show(code, paths)?;
   }
+
+  let definition = "defn render (value options) (let (result (transform value options)) (println result) result)"
+    .parse_expr_one_liner()
+    .map_err(|e| e.to_string())?;
+  let focus_options = CirruFocusOptions::default()
+    .with_focus_marker("CURSOR")
+    .with_root_prefix(3)
+    .with_target_limits(3, 2);
+  let focused = focus_cirru_preview_with_options(&definition, &[3, 2, 1], &focus_options);
+  println!("custom definition focus:");
+  print_block(
+    "result",
+    format(&[focused], CirruWriterOptions { use_inline: false })
+      .map_err(|e| e.to_string())?
+      .trim(),
+  );
 
   // A leaf is also a valid input; focusing an invalid coordinate folds the
   // available tree without panicking.

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -8,19 +8,70 @@
 
 use crate::primes::Cirru;
 
-/// Max siblings to show on each side of the focus target.
+/// Controls how a focused Cirru preview marks and folds its presentation tree.
+///
+/// The default values preserve the behavior of [`focus_cirru_preview`]. Use
+/// the builder methods instead of relying on the private field layout so more
+/// presentation options can be added without breaking callers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CirruFocusOptions {
+  focus_marker: String,
+  folded_marker: String,
+  root_prefix: usize,
+  non_target_children: usize,
+  target_children: usize,
+  non_target_depth: usize,
+  target_depth: usize,
+}
 
-/// Max children to show in non-target subtrees.
-const FOLD_CHILDREN_NON_TARGET: usize = 2;
+impl Default for CirruFocusOptions {
+  fn default() -> Self {
+    Self {
+      focus_marker: "'FOCUSED".to_string(),
+      folded_marker: "'FOLDED".to_string(),
+      root_prefix: 0,
+      non_target_children: 2,
+      target_children: 3,
+      non_target_depth: 2,
+      target_depth: 2,
+    }
+  }
+}
 
-/// Max children to show in the focus-target subtree.
-const FOLD_CHILDREN_TARGET: usize = 3;
+impl CirruFocusOptions {
+  /// Change the leaf used as the head of the focus wrapper.
+  pub fn with_focus_marker(mut self, marker: impl Into<String>) -> Self {
+    self.focus_marker = marker.into();
+    self
+  }
 
-/// Max depth for non-target subtrees before collapsing.
-const FOLD_NON_TARGET_DEPTH: usize = 2;
+  /// Change the prefix used for folded placeholder leaves.
+  pub fn with_folded_marker(mut self, marker: impl Into<String>) -> Self {
+    self.folded_marker = marker.into();
+    self
+  }
 
-/// Max depth for the focus-target subtree before collapsing.
-const FOLD_TARGET_DEPTH: usize = 2;
+  /// Preserve this many leading children of the root list verbatim when the
+  /// focus target follows them. This is useful for definition signatures.
+  pub fn with_root_prefix(mut self, count: usize) -> Self {
+    self.root_prefix = count;
+    self
+  }
+
+  /// Set the maximum visible children and depth for non-target subtrees.
+  pub fn with_non_target_limits(mut self, children: usize, depth: usize) -> Self {
+    self.non_target_children = children;
+    self.non_target_depth = depth;
+    self
+  }
+
+  /// Set the maximum visible children and depth for the focused subtree.
+  pub fn with_target_limits(mut self, children: usize, depth: usize) -> Self {
+    self.target_children = children;
+    self.target_depth = depth;
+    self
+  }
+}
 
 /// Build a `'FOLDED:...` placeholder: a single bare Cirru symbol leaf.
 ///
@@ -35,15 +86,15 @@ const FOLD_TARGET_DEPTH: usize = 2;
 /// only use ASCII letters, digits, `-` and `:` so the leaf always prints
 /// bare (unquoted, unescaped) — spaces or non-ASCII characters would force
 /// the writer to wrap it in an escaped `"..."` string.
-fn folded_place(detail: &str) -> Cirru {
-  Cirru::leaf(format!("'FOLDED:{detail}"))
+fn folded_place(detail: &str, options: &CirruFocusOptions) -> Cirru {
+  Cirru::leaf(format!("{}:{detail}", options.folded_marker))
 }
 
 /// Keep a small readable anchor when a sibling range is folded.
 ///
 /// A bare leaf is already compact, while a list contributes its head
 /// (operator/tag) and an explicit marker for its hidden body.
-fn sibling_anchor(node: &Cirru) -> Cirru {
+fn sibling_anchor(node: &Cirru, options: &CirruFocusOptions) -> Cirru {
   match node {
     Cirru::Leaf(_) => node.clone(),
     Cirru::List(xs) => {
@@ -52,44 +103,46 @@ fn sibling_anchor(node: &Cirru) -> Cirru {
       };
       let mut result = vec![head.clone()];
       if xs.len() > 1 {
-        result.push(folded_place(&format!("inside:{}", xs.len() - 1)));
+        result.push(folded_place(&format!("inside:{}", xs.len() - 1), options));
       }
       Cirru::List(result)
     }
   }
 }
 
-fn focused_node(node: Cirru) -> Cirru {
-  Cirru::List(vec![Cirru::leaf("'FOCUSED"), node])
+fn focused_node(node: Cirru, options: &CirruFocusOptions) -> Cirru {
+  Cirru::List(vec![Cirru::leaf(options.focus_marker.as_str()), node])
 }
 
-fn folded_detail(node: &Cirru) -> Option<&str> {
+fn folded_detail<'a>(node: &'a Cirru, options: &CirruFocusOptions) -> Option<&'a str> {
   match node {
-    Cirru::Leaf(value) => value.strip_prefix("'FOLDED:"),
+    Cirru::Leaf(value) => value
+      .strip_prefix(options.folded_marker.as_str())
+      .and_then(|value| value.strip_prefix(':')),
     Cirru::List(_) => None,
   }
 }
 
-fn merge_folded_runs(nodes: Vec<Cirru>) -> Vec<Cirru> {
+fn merge_folded_runs(nodes: Vec<Cirru>, options: &CirruFocusOptions) -> Vec<Cirru> {
   let mut result = Vec::with_capacity(nodes.len());
   let mut index = 0;
   while index < nodes.len() {
-    let Some(detail) = folded_detail(&nodes[index]) else {
+    let Some(detail) = folded_detail(&nodes[index], options) else {
       result.push(nodes[index].clone());
       index += 1;
       continue;
     };
 
     let mut count = 1;
-    while index + count < nodes.len() && folded_detail(&nodes[index + count]).is_some() {
+    while index + count < nodes.len() && folded_detail(&nodes[index + count], options).is_some() {
       count += 1;
     }
     if count == 1 {
       result.push(nodes[index].clone());
     } else {
-      let same_detail = (1..count).all(|offset| folded_detail(&nodes[index + offset]) == Some(detail));
+      let same_detail = (1..count).all(|offset| folded_detail(&nodes[index + offset], options) == Some(detail));
       let kind = if same_detail { detail } else { "merged" };
-      result.push(folded_place(&format!("{kind}:{count}")));
+      result.push(folded_place(&format!("{kind}:{count}"), options));
     }
     index += count;
   }
@@ -100,8 +153,8 @@ fn merge_folded_runs(nodes: Vec<Cirru>) -> Vec<Cirru> {
 ///
 /// Walks the tree via `path`, keeping only the list head and target at every
 /// nesting level. Other siblings are replaced with a single placeholder.
-/// Non-target subtrees are capped at `FOLD_NON_TARGET_DEPTH`; the focus path
-/// is capped at `FOLD_TARGET_DEPTH`.
+/// Non-target subtrees and the focus path use the limits in
+/// [`CirruFocusOptions::default`].
 ///
 /// # Example
 ///
@@ -123,26 +176,55 @@ fn merge_folded_runs(nodes: Vec<Cirru>) -> Vec<Cirru> {
 /// // sibling "e", hiding rest.
 /// ```
 pub fn focus_cirru_preview(node: &Cirru, path: &[usize]) -> Cirru {
-  focus_cirru_preview_impl(node, path, 0)
+  focus_cirru_preview_with_options(node, path, &CirruFocusOptions::default())
 }
 
-fn focus_cirru_preview_impl(node: &Cirru, path: &[usize], depth: usize) -> Cirru {
+/// Structurally focus on a path using custom presentation options.
+///
+/// `root_prefix` is applied only to the outermost list. For example, a value
+/// of 3 keeps a definition's head, name, and argument list intact while the
+/// body is focused. Markers affect only the returned presentation tree.
+///
+/// ```rust
+/// use cirru_parser::{Cirru, CirruFocusOptions, focus_cirru_preview_with_options};
+///
+/// let tree = Cirru::List(vec![
+///   Cirru::leaf("defn"),
+///   Cirru::leaf("render"),
+///   Cirru::List(vec![Cirru::leaf("value")]),
+///   Cirru::List(vec![Cirru::leaf("println"), Cirru::leaf("value")]),
+/// ]);
+/// let options = CirruFocusOptions::default()
+///   .with_focus_marker("CURSOR")
+///   .with_root_prefix(3);
+/// let preview = focus_cirru_preview_with_options(&tree, &[3, 1], &options);
+/// let Cirru::List(items) = preview else { panic!("preview should be a list") };
+/// assert_eq!(items[1], Cirru::leaf("render"));
+/// ```
+pub fn focus_cirru_preview_with_options(node: &Cirru, path: &[usize], options: &CirruFocusOptions) -> Cirru {
+  focus_cirru_preview_impl(node, path, 0, options)
+}
+
+fn focus_cirru_preview_impl(node: &Cirru, path: &[usize], depth: usize, options: &CirruFocusOptions) -> Cirru {
   match node {
     Cirru::Leaf(_) => {
       if path.is_empty() {
-        focused_node(node.clone())
+        focused_node(node.clone(), options)
       } else {
         node.clone()
       }
     }
     Cirru::List(xs) => {
       if path.is_empty() {
-        return focused_node(fold_children_impl(node, FOLD_CHILDREN_TARGET, 0, FOLD_TARGET_DEPTH));
+        return focused_node(
+          fold_children_impl(node, options.target_children, 0, options.target_depth, options),
+          options,
+        );
       }
 
       let target_idx = path[0];
       if target_idx >= xs.len() {
-        return fold_children_impl(node, FOLD_CHILDREN_NON_TARGET, 0, FOLD_NON_TARGET_DEPTH);
+        return fold_children_impl(node, options.non_target_children, 0, options.non_target_depth, options);
       }
 
       let rest_path = &path[1..];
@@ -152,28 +234,46 @@ fn focus_cirru_preview_impl(node: &Cirru, path: &[usize], depth: usize) -> Cirru
       // In Lisp-style prefix notation the head (position 0) carries
       // semantic meaning (operator / record tag / special form) — always
       // keep it visible even when siblings before the target are folded.
-      if target_idx > 0 {
-        result.push(fold_children_impl(&xs[0], FOLD_CHILDREN_NON_TARGET, 0, FOLD_NON_TARGET_DEPTH));
-      }
-      if target_idx > 1 {
-        let hidden = target_idx - 1;
-        result.push(sibling_anchor(&xs[1]));
-        if hidden > 1 {
-          result.push(folded_place(&format!("before:{}", hidden - 1)));
+      let root_prefix = if depth == 0 { options.root_prefix.min(target_idx) } else { 0 };
+      if root_prefix > 0 {
+        result.extend(xs.iter().take(root_prefix).cloned());
+        let hidden = target_idx - root_prefix;
+        if hidden > 0 {
+          result.push(sibling_anchor(&xs[root_prefix], options));
+          if hidden > 1 {
+            result.push(folded_place(&format!("before:{}", hidden - 1), options));
+          }
+        }
+      } else {
+        if target_idx > 0 {
+          result.push(fold_children_impl(
+            &xs[0],
+            options.non_target_children,
+            0,
+            options.non_target_depth,
+            options,
+          ));
+        }
+        if target_idx > 1 {
+          let hidden = target_idx - 1;
+          result.push(sibling_anchor(&xs[1], options));
+          if hidden > 1 {
+            result.push(folded_place(&format!("before:{}", hidden - 1), options));
+          }
         }
       }
 
-      result.push(focus_cirru_preview_impl(&xs[target_idx], rest_path, depth + 1));
+      result.push(focus_cirru_preview_impl(&xs[target_idx], rest_path, depth + 1, options));
 
       let remaining = xs.len() - target_idx - 1;
       if remaining > 0 {
-        result.push(sibling_anchor(&xs[target_idx + 1]));
+        result.push(sibling_anchor(&xs[target_idx + 1], options));
         if remaining > 1 {
-          result.push(folded_place(&format!("after:{}", remaining - 1)));
+          result.push(folded_place(&format!("after:{}", remaining - 1), options));
         }
       }
 
-      Cirru::List(merge_folded_runs(result))
+      Cirru::List(merge_folded_runs(result, options))
     }
   }
 }
@@ -187,30 +287,30 @@ fn focus_cirru_preview_impl(node: &Cirru, path: &[usize], depth: usize) -> Cirru
 /// - The head of a list (index 0) — the operator/tag/field-name in Cirru's
 ///   Lisp-style prefix notation — is always kept visible and does not count
 ///   against `max_children`; only the remaining elements can be folded.
-fn fold_children_impl(node: &Cirru, max_children: usize, depth: usize, max_depth: usize) -> Cirru {
+fn fold_children_impl(node: &Cirru, max_children: usize, depth: usize, max_depth: usize, options: &CirruFocusOptions) -> Cirru {
   match node {
     Cirru::Leaf(_) => node.clone(),
     Cirru::List(xs) => {
       if depth >= max_depth {
-        return folded_place("max-depth");
+        return folded_place("max-depth", options);
       }
       let Some((head, rest)) = xs.split_first() else {
         return node.clone();
       };
-      let mut result = vec![fold_children_impl(head, max_children, depth + 1, max_depth)];
+      let mut result = vec![fold_children_impl(head, max_children, depth + 1, max_depth, options)];
       let hidden = rest.len().saturating_sub(max_children);
       // Don't bother folding 1–2 nodes — just show them
       if hidden <= 2 {
         for c in rest {
-          result.push(fold_children_impl(c, max_children, depth + 1, max_depth));
+          result.push(fold_children_impl(c, max_children, depth + 1, max_depth, options));
         }
-        return Cirru::List(merge_folded_runs(result));
+        return Cirru::List(merge_folded_runs(result, options));
       }
       for c in rest.iter().take(max_children) {
-        result.push(fold_children_impl(c, max_children, depth + 1, max_depth));
+        result.push(fold_children_impl(c, max_children, depth + 1, max_depth, options));
       }
-      result.push(folded_place(&format!("inside:{hidden}")));
-      Cirru::List(merge_folded_runs(result))
+      result.push(folded_place(&format!("inside:{hidden}"), options));
+      Cirru::List(merge_folded_runs(result, options))
     }
   }
 }
@@ -267,7 +367,7 @@ mod tests {
     let tree = Cirru::List(vec![leaf("root"), Cirru::List(vec![leaf("a")]), Cirru::List(vec![leaf("b")])]);
 
     assert_eq!(
-      fold_children_impl(&tree, 3, 0, 1),
+      fold_children_impl(&tree, 3, 0, 1, &CirruFocusOptions::default()),
       Cirru::List(vec![leaf("root"), leaf("'FOLDED:max-depth:2")])
     );
   }
@@ -277,5 +377,50 @@ mod tests {
     let tree = Cirru::List(vec![leaf("root"), leaf("child")]);
 
     assert_eq!(focus_cirru_preview(&tree, &[4]), Cirru::List(vec![leaf("root"), leaf("child")]));
+  }
+
+  #[test]
+  fn custom_options_preserve_root_signature_and_change_markers() {
+    let args = Cirru::List(vec![leaf("value"), leaf("options")]);
+    let tree = Cirru::List(vec![
+      leaf("defn"),
+      leaf("render"),
+      args.clone(),
+      Cirru::List(vec![leaf("let"), leaf("target"), leaf("tail")]),
+      leaf("metadata"),
+    ]);
+    let options = CirruFocusOptions::default()
+      .with_focus_marker("CURSOR")
+      .with_folded_marker("FOLDED")
+      .with_root_prefix(3);
+    let focused = focus_cirru_preview_with_options(&tree, &[3, 1], &options);
+    let Cirru::List(items) = focused else {
+      panic!("focused definition should remain a list")
+    };
+    assert_eq!(&items[..3], &[leaf("defn"), leaf("render"), args]);
+    assert_eq!(
+      items[3],
+      Cirru::List(vec![leaf("let"), Cirru::List(vec![leaf("CURSOR"), leaf("target")]), leaf("tail"),])
+    );
+    assert_eq!(items[4], leaf("metadata"));
+  }
+
+  #[test]
+  fn custom_options_tune_target_and_non_target_fold_limits() {
+    let tree = Cirru::List(vec![leaf("root"), leaf("a"), leaf("b"), leaf("c"), leaf("d")]);
+    let target_options = CirruFocusOptions::default().with_target_limits(1, 2);
+    assert_eq!(
+      focus_cirru_preview_with_options(&tree, &[], &target_options),
+      Cirru::List(vec![
+        leaf("'FOCUSED"),
+        Cirru::List(vec![leaf("root"), leaf("a"), leaf("'FOLDED:inside:3")]),
+      ])
+    );
+
+    let non_target_options = CirruFocusOptions::default().with_non_target_limits(0, 2);
+    assert_eq!(
+      focus_cirru_preview_with_options(&tree, &[9], &non_target_options),
+      Cirru::List(vec![leaf("root"), leaf("'FOLDED:inside:4")])
+    );
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,8 +24,8 @@ find more on <http://text.cirru.org/> .
 */
 
 mod error;
-mod primes;
 mod focus;
+mod primes;
 mod s_expr;
 mod tree;
 mod writer;
@@ -45,9 +45,9 @@ use std::cmp::Ordering::*;
 use primes::CirruLexState;
 use tree::{resolve_comma, resolve_dollar};
 
+pub use focus::{CirruFocusOptions, focus_cirru_preview, focus_cirru_preview_with_options};
 pub use primes::{Cirru, CirruLexItem, CirruLexItemList, escape_cirru_leaf};
 pub use s_expr::format_to_lisp;
-pub use focus::focus_cirru_preview;
 pub use writer::{CirruOneLinerExt, CirruWriterOptions, format, format_expr_one_liner, generate_leaf};
 
 /// Helper function to format and print a detailed error

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -65,7 +65,7 @@ mod json_test {
       let cirru_str = fs::read_to_string(format!("./tests/cirru/{file}.cirru"))?;
 
       assert_eq!(
-        parse(&cirru_str).map(|r| Cirru::List(r)).map_err(|e| e.to_string()),
+        parse(&cirru_str).map(Cirru::List).map_err(|e| e.to_string()),
         from_json_str(&json_str)
       );
     }


### PR DESCRIPTION
Adds a backward-compatible CirruFocusOptions API for custom focus/fold markers, root-prefix preservation, and target/non-target folding limits. Keeps focus_cirru_preview defaults unchanged. Includes unit tests, doctests, README docs, and an executable example. Local cargo test, serde-json tests, and clippy all pass.